### PR TITLE
Updated Adwaita-Dark .jwmrc

### DIFF
--- a/etc/skel/.config/jwm/Adwaita-Dark/.jwmrc
+++ b/etc/skel/.config/jwm/Adwaita-Dark/.jwmrc
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <JWM>
 
-<!-- THEME NAME: DEEPIN DARK -->
+<!-- THEME NAME: ADWAITA DARK -->
 
     	<!-- The root menu. -->
     	<RootMenu onroot="12">
@@ -106,13 +106,13 @@ label="picom.conf">leafpad ~/.config/picom.conf</Program>
     	<!--STARTUP COMMANDS-->
 	<StartupCommand>/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1</StartupCommand> 
         <StartupCommand>nitrogen --restore</StartupCommand>
-   	<!--<StartupCommand>picom</StartupCommand>-->  
+   	<StartupCommand>picom</StartupCommand>  
 	<StartupCommand>volumeicon</StartupCommand> 
 	<StartupCommand>nm-applet</StartupCommand>
 	<StartupCommand>xset s off -dpms</StartupCommand>
 	<StartupCommand>xrdb -load .Xresources</StartupCommand>
 	<StartupCommand>/usr/lib/xfce4/notifyd/xfce4-notifyd</StartupCommand>
-        <!--<StartupCommand>sleep 4&&conky</StartupCommand>-->
+        <StartupCommand>sleep 4&&conky</StartupCommand>
 
 	<!-- STARTUP COMMANDS FOR TOUCHPAD CONTROLS -->
     	<!--To disable the touchpad while typing, uncomment the next line.-->


### PR DESCRIPTION
Updated the .jwmrc file in /etc/skel/.config/jwm/Adwaita-Dark/ to reflect the correct theme name and set both conky and picom to autostart.