### PR TITLE
Updated Deepin-Dark .jwmrc

### DIFF
--- a/etc/skel/.config/jwm/Deepin-Dark/.jwmrc
+++ b/etc/skel/.config/jwm/Deepin-Dark/.jwmrc
@@ -106,13 +106,13 @@ label="picom.conf">leafpad ~/.config/picom.conf</Program>
     	<!--STARTUP COMMANDS-->
 	<StartupCommand>/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1</StartupCommand> 
         <StartupCommand>nitrogen --restore</StartupCommand>
-   	<!--<StartupCommand>picom</StartupCommand>-->  
+   	<StartupCommand>picom</StartupCommand>  
 	<StartupCommand>volumeicon</StartupCommand> 
 	<StartupCommand>nm-applet</StartupCommand>
 	<StartupCommand>xset s off -dpms</StartupCommand>
 	<StartupCommand>xrdb -load .Xresources</StartupCommand>
 	<StartupCommand>/usr/lib/xfce4/notifyd/xfce4-notifyd</StartupCommand>
-        <!--<StartupCommand>sleep 4&&conky</StartupCommand>-->
+        <StartupCommand>sleep 4&&conky</StartupCommand>
 
 	<!-- STARTUP COMMANDS FOR TOUCHPAD CONTROLS -->
     	<!--To disable the touchpad while typing, uncomment the next line.-->


### PR DESCRIPTION
Updated the Deepin-Dark .jwmrc in /etc/skel/.config/jwm/Deepin-Dark/ to reflect having conky and picom run at system startup.