### PR TITLE
Updated default .jwmrc

### DIFF
--- a/etc/skel/.jwmrc
+++ b/etc/skel/.jwmrc
@@ -106,13 +106,13 @@ label="picom.conf">leafpad ~/.config/picom.conf</Program>
     	<!--STARTUP COMMANDS-->
 	<StartupCommand>/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1</StartupCommand> 
         <StartupCommand>nitrogen --restore</StartupCommand>
-   	<!--<StartupCommand>picom</StartupCommand>-->  
+   	<StartupCommand>picom</StartupCommand>  
 	<StartupCommand>volumeicon</StartupCommand> 
 	<StartupCommand>nm-applet</StartupCommand>
 	<StartupCommand>xset s off -dpms</StartupCommand>
 	<StartupCommand>xrdb -load .Xresources</StartupCommand>
 	<StartupCommand>/usr/lib/xfce4/notifyd/xfce4-notifyd</StartupCommand>
-        <!--<StartupCommand>sleep 4&&conky</StartupCommand>-->
+        <StartupCommand>sleep 4&&conky</StartupCommand>
 
 	<!-- STARTUP COMMANDS FOR TOUCHPAD CONTROLS -->
     	<!--To disable the touchpad while typing, uncomment the next line.-->


### PR DESCRIPTION
Updated the default .jwmrc file in /etc/skel/HOME/ to have conky and picom run at system-startup.